### PR TITLE
Adding JIRA ServiceDesk and JIRA Core as options to install

### DIFF
--- a/templates/JiraDataCenter.template
+++ b/templates/JiraDataCenter.template
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "QS(0035) Atlassian Jira Data Center Oct,7,2016",
+  "Description": "QS(0035) Atlassian Jira Data Center Nov,4,2016",
   "Metadata": {
     "AWS::CloudFormation::Interface": {
       "ParameterGroups": [
@@ -9,7 +9,7 @@
             "default": "JIRA setup"
           },
           "Parameters": [
-            "JiraVersion"
+            "JiraProduct"
           ]
         },
         {
@@ -93,8 +93,8 @@
         "DBIops": {
           "default": "RDS Provisioned IOPS"
         },
-        "JiraVersion": {
-          "default": "Version *"
+        "JiraProduct": {
+          "default": "JIRA Product *"
         },
         "KeyName": {
           "default": "Key Name *"
@@ -228,14 +228,14 @@
       "MaxValue": "30000",
       "ConstraintDescription": "Must be in the range 1000 - 30000."
     },
-    "JiraVersion": {
-      "Description": "The version of JIRA to install",
-	  "Default": "7.2.3-AWS-SUMMIT-DEMO",
+    "JiraProduct": {
+      "Description": "The JIRA Product to install. Installs latest available version of the selected product",
       "Type": "String",
-      "AllowedPattern": "(\\d+\\.\\d+\\.\\d+(-?.*))",
-      "ConstraintDescription": "Must be a valid JIRA version number. For example: 7.2.3 or higher",
+      "ConstraintDescription": "Must be \"Software\", \"ServiceDesk\", or \"Core\"",
       "AllowedValues": [
-        "7.2.3-AWS-SUMMIT-DEMO"
+        "Software",
+        "ServiceDesk",
+        "Core"
       ]
     },
     "KeyName": {
@@ -453,6 +453,26 @@
         "HVM64": "ami-cf1dc5af",
         "HVMG2": "NOT_SUPPORTED"
       }
+    },
+    "JIRAProduct2NameAndVersion" : {
+      "Software": {
+        "name" : "jira-software",
+        "version" : "7.2.3",
+        "shortdisplayname" : "\"JIRA SW\"",
+        "fulldisplayname" : "\"Atlassian JIRA Software\""
+      },
+      "ServiceDesk": {
+        "name" : "servicedesk",
+        "version" : "3.2.3",
+        "shortdisplayname" : "\"JIRA SD\"",
+        "fulldisplayname" : "\"Atlassian JIRA Service Desk\""
+      },
+      "Core": {
+        "name" : "jira-core",
+        "version" : "7.2.3",
+        "shortdisplayname" : "\"JIRA Core\"",
+        "fulldisplayname" : "\"Atlassian JIRA Core\""
+      }
     }
   },
   "Resources": {
@@ -564,11 +584,51 @@
                       "\n",
                       "ATL_ENABLED_PRODUCTS=Jira\n",
                       "ATL_ENABLED_SHARED_HOMES=\n",
-                      "ATL_JIRA_VERSION=",
+                      "ATL_JIRA_NAME=",
                       {
-                        "Ref": "JiraVersion"
+                        "Fn::FindInMap": [
+                          "JIRAProduct2NameAndVersion",
+                          {
+                            "Ref": "JiraProduct"
+                          },
+                          "name"
+                        ]
                       },
                       "\n",
+                      "ATL_JIRA_VERSION=",
+                      {
+                        "Fn::FindInMap": [
+                          "JIRAProduct2NameAndVersion",
+                          {
+                            "Ref": "JiraProduct"
+                          },
+                          "version"
+                        ]
+                      },
+                      "\n",
+                      "ATL_JIRA_SHORT_DISPLAY_NAME=",
+                      {
+                        "Fn::FindInMap": [
+                          "JIRAProduct2NameAndVersion",
+                          {
+                            "Ref": "JiraProduct"
+                          },
+                          "shortdisplayname"
+                        ]
+                      },
+                      "\n",
+                      "ATL_JIRA_FULL_DISPLAY_NAME=",
+                      {
+                        "Fn::FindInMap": [
+                          "JIRAProduct2NameAndVersion",
+                          {
+                            "Ref": "JiraProduct"
+                          },
+                          "fulldisplayname"
+                        ]
+                      },
+                      "\n",
+                      "ATL_RELEASE_S3_PATH=releases/jira\n",
                       "ATL_JIRA_DATA_CENTER=true\n",
                       "ATL_NGINX_ENABLED=false\n",
                       "ATL_POSTGRES_ENABLED=false\n",

--- a/templates/quickstart-jira-master.json
+++ b/templates/quickstart-jira-master.json
@@ -28,8 +28,8 @@
         "ParameterValue": "Provisioned IOPS"
     },
     {
-        "ParameterKey": "JiraVersion",
-        "ParameterValue": "7.2.3-AWS-SUMMIT-DEMO"
+        "ParameterKey": "JiraProduct",
+        "ParameterValue": "Software"
     },
     {
         "ParameterKey": "KeyPairName",

--- a/templates/quickstart-jira-master.template
+++ b/templates/quickstart-jira-master.template
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Atlassian Jira Data Center in new VPC License: Apache 2.0 (Please do not remove) Oct,7,2016",
+  "Description": "Atlassian Jira Data Center in new VPC License: Apache 2.0 (Please do not remove) Nov,4,2016",
   "Metadata": {
     "AWS::CloudFormation::Interface": {
       "ParameterGroups": [{
@@ -22,7 +22,7 @@
           "default": "JIRA Setup"
         },
         "Parameters": [
-          "JiraVersion",
+          "JiraProduct",
           "ClusterNodeMax",
           "ClusterNodeMin",
           "ClusterNodeInstanceType",
@@ -93,8 +93,8 @@
         "AssociatePublicIpAddress": {
           "default": "Assign public IP"
         },
-        "JiraVersion": {
-          "default": "Version"
+        "JiraProduct": {
+          "default": "JIRA Product"
         },
         "CatalinaOpts": {
           "default": "Catalina Options"
@@ -216,13 +216,15 @@
       ],
       "ConstraintDescription": "Must be 'true' or 'false'."
     },
-    "JiraVersion": {
-      "Description": "Version of JIRA to install. Find valid versions at https://www.atlassian.com/software/jira/download-archives.html",
+    "JiraProduct": {
+      "Description": "The JIRA Product to install. Installs latest available version of the selected product",
       "Type": "String",
-      "Default": "7.2.3-AWS-SUMMIT-DEMO",
-      "MinLength": "5",
-      "MaxLength": "27",
-      "ConstraintDescription": "Must be a valid JIRA version number."
+      "ConstraintDescription": "Must be \"Software\", \"ServiceDesk\", or \"Core\"",
+      "AllowedValues": [
+        "Software",
+        "ServiceDesk",
+        "Core"
+      ]
     },
     "ClusterNodeMax": {
       "Type": "Number",
@@ -510,6 +512,7 @@
             "/", [{
                 "Fn::FindInMap": [
                   "AWSInfoRegionMap", {
+                  "AWSInfoRegionMap", {
                     "Ref": "AWS::Region"
                   },
                   "QuickStartS3URL"
@@ -571,8 +574,8 @@
           "AssociatePublicIpAddress": {
             "Ref": "AssociatePublicIpAddress"
           },
-          "JiraVersion": {
-            "Ref": "JiraVersion"
+          "JiraProduct": {
+            "Ref": "JiraProduct"
           },
           "ClusterNodeMax": {
             "Ref": "ClusterNodeMax"


### PR DESCRIPTION
We are replacing version parameter with product parameter in template. 
Our plan is to make template install only the latest versions of the products. 
As MVP we have hardcoded specific versions that are uploaded to Atlassian S3 bucket.