### PR TITLE
Feature/jira datacenter template always installes latest version of jira available

### DIFF
--- a/templates/JiraDataCenter.template
+++ b/templates/JiraDataCenter.template
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "QS(0035) Atlassian Jira Data Center Oct,3,2016",
+  "Description": "Atlassian JIRA Data Center",
   "Metadata": {
     "AWS::CloudFormation::Interface": {
       "ParameterGroups": [
@@ -9,7 +9,7 @@
             "default": "JIRA setup"
           },
           "Parameters": [
-            "JiraVersion"
+            "JiraProduct"
           ]
         },
         {
@@ -93,8 +93,8 @@
         "DBIops": {
           "default": "RDS Provisioned IOPS"
         },
-        "JiraVersion": {
-          "default": "Version *"
+        "JiraProduct": {
+          "default": "JIRA Product *"
         },
         "KeyName": {
           "default": "Key Name *"
@@ -228,13 +228,14 @@
       "MaxValue": "30000",
       "ConstraintDescription": "Must be in the range 1000 - 30000."
     },
-    "JiraVersion": {
-      "Description": "The version of JIRA to install",
+    "JiraProduct": {
+      "Description": "The JIRA Product to install. Installs latest available version of the selected product",
       "Type": "String",
-      "AllowedPattern": "(\\d+\\.\\d+\\.\\d+(-?.*))",
-      "ConstraintDescription": "Must be a valid JIRA version number. For example: 7.2.3 or higher",
+      "ConstraintDescription": "Must be \"Software\", \"ServiceDesk\", or \"Core\"",
       "AllowedValues": [
-        "7.3.0-SNAPSHOT"
+        "Software",
+        "ServiceDesk",
+        "Core"
       ]
     },
     "KeyName": {
@@ -409,48 +410,77 @@
     },
     "AWSRegionArch2AMI": {
       "us-east-1": {
-        "HVM64": "ami-805a1b97",
+        "HVM64": "ami-bb5642ac",
         "HVMG2": "NOT_SUPPORTED"
       },
       "ap-south-1": {
-        "HVM64": "ami-1133477e",
+        "HVM64": "ami-67c6b108",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "eu-west-2": {
+        "HVM64": "ami-eeede78a",
         "HVMG2": "NOT_SUPPORTED"
       },
       "eu-west-1": {
-        "HVM64": "ami-442a6c37",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-southeast-1": {
-        "HVM64": "ami-6882260b",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-southeast-2": {
-        "HVM64": "ami-db3201b8",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "eu-central-1": {
-        "HVM64": "ami-d46599bb",
+        "HVM64": "ami-afcaeadc",
         "HVMG2": "NOT_SUPPORTED"
       },
       "ap-northeast-2": {
-        "HVM64": "ami-4590442b",
+        "HVM64": "ami-15a0767b",
         "HVMG2": "NOT_SUPPORTED"
       },
       "ap-northeast-1": {
-        "HVM64": "ami-87f32ce6",
+        "HVM64": "ami-da107bbd",
         "HVMG2": "NOT_SUPPORTED"
       },
       "sa-east-1": {
-        "HVM64": "ami-f7fc6e9b",
+        "HVM64": "ami-5a71e936",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "ca-central-1": {
+        "HVM64": "ami-ab2a98cf",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "ap-southeast-1": {
+        "HVM64": "ami-b7ae00d4",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "ap-southeast-2": {
+        "HVM64": "ami-5bc2f938",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "eu-central-1": {
+        "HVM64": "ami-982aeaf7",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "us-east-2": {
+        "HVM64": "ami-1ccc9679",
         "HVMG2": "NOT_SUPPORTED"
       },
       "us-west-1": {
-        "HVM64": "ami-82e7a9e2",
+        "HVM64": "ami-f0267790",
         "HVMG2": "NOT_SUPPORTED"
       },
       "us-west-2": {
-        "HVM64": "ami-2714ca47",
+        "HVM64": "ami-560fbb36",
         "HVMG2": "NOT_SUPPORTED"
+      }
+    },
+    "JIRAProduct2NameAndVersion": {
+      "Software": {
+        "name": "jira-software",
+        "shortdisplayname": "\"JIRA SW\"",
+        "fulldisplayname": "\"Atlassian JIRA Software\""
+      },
+      "ServiceDesk": {
+        "name": "servicedesk",
+        "shortdisplayname": "\"JIRA SD\"",
+        "fulldisplayname": "\"Atlassian JIRA Service Desk\""
+      },
+      "Core": {
+        "name": "jira-core",
+        "shortdisplayname": "\"JIRA Core\"",
+        "fulldisplayname": "\"Atlassian JIRA Core\""
       }
     }
   },
@@ -516,13 +546,15 @@
                   "Fn::Join": [
                     "",
                     [
+                      "ATL_NGINX_ENABLED=false\n",
                       "ATL_APP_DATA_MOUNT_ENABLED=false\n",
+                      "ATL_DB_NAME=jira\n",
+                      "ATL_DB_USER=jira\n",
                       "ATL_DB_PASSWORD=",
                       {
                         "Ref": "DBMasterUserPassword"
                       },
                       "\n",
-                      "ATL_DB_NAME=jira\n",
                       "ATL_DB_HOST=",
                       {
                         "Fn::GetAtt": [
@@ -563,13 +595,41 @@
                       "\n",
                       "ATL_ENABLED_PRODUCTS=Jira\n",
                       "ATL_ENABLED_SHARED_HOMES=\n",
-                      "ATL_JIRA_VERSION=",
+                      "ATL_JIRA_NAME=",
                       {
-                        "Ref": "JiraVersion"
+                        "Fn::FindInMap": [
+                          "JIRAProduct2NameAndVersion",
+                          {
+                            "Ref": "JiraProduct"
+                          },
+                          "name"
+                        ]
                       },
                       "\n",
-                      "ATL_JIRA_DATA_CENTER=true\n",
-                      "ATL_NGINX_ENABLED=false\n",
+                      "ATL_JIRA_SHORT_DISPLAY_NAME=",
+                      {
+                        "Fn::FindInMap": [
+                          "JIRAProduct2NameAndVersion",
+                          {
+                            "Ref": "JiraProduct"
+                          },
+                          "shortdisplayname"
+                        ]
+                      },
+                      "\n",
+                      "ATL_JIRA_FULL_DISPLAY_NAME=",
+                      {
+                        "Fn::FindInMap": [
+                          "JIRAProduct2NameAndVersion",
+                          {
+                            "Ref": "JiraProduct"
+                          },
+                          "fulldisplayname"
+                        ]
+                      },
+                      "\n",
+                      "ATL_RELEASE_S3_BUCKET=atlassian-software\n",
+                      "ATL_RELEASE_S3_PATH=releases\n",
                       "ATL_POSTGRES_ENABLED=false\n",
                       "ATL_PROXY_NAME=",
                       {

--- a/templates/JiraDataCenter.template
+++ b/templates/JiraDataCenter.template
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Atlassian JIRA Data Center",
+  "Description": "QS(0035) Atlassian Jira Data Center Oct,3,2016",
   "Metadata": {
     "AWS::CloudFormation::Interface": {
       "ParameterGroups": [


### PR DESCRIPTION
Hello!

This is updated JiraDataCenter template.
I've updated AMIs with scripts to download and preserve JIRAs installers. The AMI checks the "latest" file in S3 bucket from now on and downloads installer for version specified in this file. The AMI script stores that installer in shared home directory, so whenever new node comes up it doesn't need to download the installer. We also are now allowing to change the product to be installed - JIRA Software, JIRA Core or Service Desk.

Jira DC template has been updated to reflect those changes.
I'm afraid it can break Quick Start template and you guys will need to updated it too.