### PR TITLE
DCD-98: Update Jira version to 7.13.1 and remove latest

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -460,7 +460,7 @@ Parameters:
     ConstraintDescription: Must be a valid Jira download url from version 7 or higher
   JiraProduct:
     Default: All
-    Description: The Jira Product to install. Installs latest available version of the selected product
+    Description: The Jira product to install.
     Type: String
     ConstraintDescription: 'Must be "Core", "Software", "ServiceDesk", or "All"'
     AllowedValues:
@@ -469,9 +469,9 @@ Parameters:
       - ServiceDesk
       - Software
   JiraVersion:
-    Default: latest
-    AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
-    ConstraintDescription: Must be a valid Jira version number, for example 7.2.3. Find valid versions at https://jira.atlassian.com/display/DOC/Jira+Release+Notes
+    Default: 7.13.1
+    AllowedPattern: '(\d+\.\d+\.\d+(-?.*))'
+    ConstraintDescription: Must be a valid Jira version number, for example 7.13.1. Find valid versions at https://jira.atlassian.com/display/DOC/Jira+Release+Notes
     Description: The version of Jira to install
     Type: String
   JvmHeapOverride:

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -440,7 +440,7 @@ Parameters:
     ConstraintDescription: Must be a valid Jira download url from version 7 or higher
   JiraProduct:
     Default: All
-    Description: The Jira Product to install. Installs latest available version of the selected product
+    Description: The Jira product to install.
     Type: String
     ConstraintDescription: 'Must be "Core", "Software", "ServiceDesk", or "All"'
     AllowedValues:
@@ -449,9 +449,9 @@ Parameters:
       - ServiceDesk
       - Software
   JiraVersion:
-    Default: latest
-    AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
-    ConstraintDescription: Must be a valid Jira version number, for example 7.2.3. Find valid versions at https://jira.atlassian.com/display/DOC/Jira+Release+Notes
+    Default: 7.13.1
+    AllowedPattern: '(\d+\.\d+\.\d+(-?.*))'
+    ConstraintDescription: Must be a valid Jira version number, for example 7.13.1. Find valid versions at https://jira.atlassian.com/display/DOC/Jira+Release+Notes
     Description: The version of Jira to install
     Type: String
   JvmHeapOverride:


### PR DESCRIPTION
This PR updates Jira version to the latest released version and also removes `latest` as possible value. Using `latest` was problematic in the template in case the stack had autoscaling enabled and might end up in a situation that the newly created node had a different version installed.