### PR TITLE
Update parameter descriptions in Jira quickstarts

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -532,7 +532,6 @@ Parameters:
       - true
       - false
     ConstraintDescription: Must be 'true' or 'false'.
-    Description: Start the collectd service
     Type: String
   TomcatAcceptCount:
     Default: 10

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -501,7 +501,6 @@ Parameters:
       - true
       - false
     ConstraintDescription: Must be 'true' or 'false'.
-    Description: Start the collectd service
     Type: String
   TomcatAcceptCount:
     Default: 10


### PR DESCRIPTION
* removed duplicated `StartCollectd` description
* add `JiraVersion` details to explain that ServiceDesk has different versioning scheme