### PR TITLE
fixes failing taskcat build as  S3 prefix is not valid

### DIFF
--- a/ci/quickstart-jira-dc-params.json
+++ b/ci/quickstart-jira-dc-params.json
@@ -33,7 +33,7 @@
     },
     {
         "ParameterKey":"QSS3KeyPrefix",
-        "ParameterValue":"quickstart-atlassian-services/"
+        "ParameterValue":"quickstart-atlassian-jira/"
     },
     {
         "ParameterKey":"AccessCIDR",


### PR DESCRIPTION
Adds a valid S3 prefix to taskcat ci parameters