### PR TITLE
Included updates to the master Jira templates to support GovCloud

### DIFF
--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -933,6 +933,12 @@ Mappings:
     us-west-2:
       HVM64: ami-0cb72367e98845d43
       HVMG2: NOT_SUPPORTED
+    us-gov-west-1:
+      HVM64: ami-e9a9d388
+      HVMG2: NOT_SUPPORTED
+    us-gov-east-1:
+      HVM64: ami-a2d938d3
+      HVMG2: NOT_SUPPORTED
 
   JIRAProduct2NameAndVersion:
     Core:
@@ -959,8 +965,8 @@ Resources:
               Service: [ec2.amazonaws.com]
             Action: ['sts:AssumeRole']
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
-        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
       Path: /
       Policies:
         - PolicyName: JiraClusterNodePolicy
@@ -977,10 +983,11 @@ Resources:
                 - "route53:ChangeResourceRecordSets"
                 Effect: Allow
                 Resource:
-                  - "arn:aws:route53:::healthcheck/*"
-                  - "arn:aws:route53:::change/*"
-                  - "arn:aws:route53:::hostedzone/*"
-                  - "arn:aws:route53:::delegationset/*"
+                  - !Sub 'arn:${AWS::Partition}:route53:::healthcheck/*'
+                  - !Sub 'arn:${AWS::Partition}:route53:::healthcheck/*'
+                  - !Sub 'arn:${AWS::Partition}:route53:::change/*'
+                  - !Sub 'arn:${AWS::Partition}:route53:::hostedzone/*'
+                  - !Sub 'arn:${AWS::Partition}:route53:::delegationset/*'
   JiraClusterNodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -1347,7 +1354,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:root"
+                - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
             Action: 'kms:*'
             Resource: '*'
       Tags:


### PR DESCRIPTION
*Description of changes:*
Included updates to the master Jira templates to support GovCloud configuration. Changes include differences in S3 URL structure and ARN policy structure. Also updated AMIs available for the Amazon Linux 2 instance that are available in GovCloud regions. This has been tested and works in a new GovCloud region. Please note that the RDS instance class size needs to be of the db.m4 family size instead of the default db.m5 class which is not available in GovCloud currently. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
