### PR TITLE
Make webservers accessible for ssh from bastion

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -535,7 +535,7 @@ Parameters:
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances.
-    Type: List<AWS::EC2::Keypair>
+    Type: AWS::EC2::KeyPair::KeyName
     Default: ''
   MailEnabled:
     AllowedValues:

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -534,8 +534,8 @@ Parameters:
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
-    Type: String
+    Description: The EC2 Key Pair to allow SSH access to the instances.
+    Type: List<AWS::EC2::Keypair>
     Default: ''
   MailEnabled:
     AllowedValues:

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1356,6 +1356,14 @@ Resources:
           ToPort: 22
           CidrIp: !Ref CidrBlock
         - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp:
+            !Sub
+              - "${BastionIp}/32"
+              - BastionIp:
+                  Fn::ImportValue: !Sub '${ExportPrefix}BastionPrivIp'
+        - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
           CidrIp: !Ref CidrBlock


### PR DESCRIPTION
Imports the private IP of the bastion host from the ASI so that when CidrBlock is set the Bastion can still SSH to the webserver.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
