### PR TITLE
DCD-1051: Gov arn for gov region

### DIFF
--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1028,7 +1028,9 @@ Resources:
               - Action:
                   - 'ssm:PutParameter'
                 Effect: Allow
-                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha"
+                Resource: !Sub
+                  - arn:${ArnPartition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha
+                  - ArnPartition: !If ["GovCloudCondition", "aws-us-gov", "aws"]
   JiraClusterNodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
Ran custom Jira CI plan (temporarily updated Jira submodules to point to updated quickstart-atlassian-services and updated quickstart-amazon-aurora) results for which are below:

https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSJIRA64-JSMOKDEPLOY-9/log

Deploys passed and all but the HTTP acceptance tests which I believe to be a dud (looking at the logs). This run should confirm these AWS partition changes across the board for Jira and the other products; BB, Connie, Crowd

These changes have also been tested in a Gov account and are shown to work, where we no longer have failing deployments
