### PR TITLE
February Quick Start update

### DIFF
--- a/ci/params/dbVersions/quickstart-jira-aurora-10.json
+++ b/ci/params/dbVersions/quickstart-jira-aurora-10.json
@@ -1,0 +1,50 @@
+[
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "10"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "Amazon Aurora PostgreSQL"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "ClusterNodeInstanceType",
+    "ParameterValue": "t3.medium"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t3.medium"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-jira/"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
+  }
+]

--- a/ci/params/dbVersions/quickstart-jira-aurora-11.json
+++ b/ci/params/dbVersions/quickstart-jira-aurora-11.json
@@ -1,0 +1,50 @@
+[
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "11"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "Amazon Aurora PostgreSQL"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "ClusterNodeInstanceType",
+    "ParameterValue": "t3.medium"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t3.medium"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-jira/"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
+  }
+]

--- a/ci/params/dbVersions/quickstart-jira-aurora-9.json
+++ b/ci/params/dbVersions/quickstart-jira-aurora-9.json
@@ -1,0 +1,50 @@
+[
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "9"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "Amazon Aurora PostgreSQL"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "ClusterNodeInstanceType",
+    "ParameterValue": "t3.medium"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.r5.large"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-jira/"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
+  }
+]

--- a/ci/params/dbVersions/quickstart-jira-postgres-10.json
+++ b/ci/params/dbVersions/quickstart-jira-postgres-10.json
@@ -1,0 +1,50 @@
+[
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "10"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "PostgreSQL"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "ClusterNodeInstanceType",
+    "ParameterValue": "t3.medium"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t3.medium"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-jira/"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
+  }
+]

--- a/ci/params/dbVersions/quickstart-jira-postgres-11.json
+++ b/ci/params/dbVersions/quickstart-jira-postgres-11.json
@@ -1,0 +1,50 @@
+[
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "11"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "PostgreSQL"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "ClusterNodeInstanceType",
+    "ParameterValue": "t3.medium"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t3.medium"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-jira/"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
+  }
+]

--- a/ci/params/dbVersions/quickstart-jira-postgres-9.json
+++ b/ci/params/dbVersions/quickstart-jira-postgres-9.json
@@ -1,0 +1,50 @@
+[
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "9"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "PostgreSQL"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "ClusterNodeInstanceType",
+    "ParameterValue": "t3.medium"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t3.medium"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-jira/"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
+  }
+]

--- a/ci/params/dbVersions/taskcat.yml
+++ b/ci/params/dbVersions/taskcat.yml
@@ -1,0 +1,57 @@
+---
+global:
+  qsname: quickstart-atlassian-jira
+  owner: quickstart-eng@amazon.com
+  marketplace-ami: false
+  reporting: true
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+
+tests:
+  JIRA-aurora-9:
+    template_file: quickstart-jira-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-jira-aurora-9.json
+    regions:
+     - us-east-1
+     
+  JIRA-aurora-10:
+    template_file: quickstart-jira-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-jira-aurora-10.json
+    regions:
+     - us-east-1
+
+  JIRA-aurora-11:
+    template_file: quickstart-jira-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-jira-aurora-11.json
+    regions:
+     - us-east-1
+
+  JIRA-postgres-9:
+    template_file: quickstart-jira-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-jira-postgres-9.json
+    regions:
+     - us-east-1
+    
+  JIRA-postgres-10:
+    template_file: quickstart-jira-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-jira-postgres-10.json
+    regions:
+     - us-east-1
+
+  JIRA-postgres-11:
+    template_file: quickstart-jira-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-jira-postgres-11.json
+    regions:
+     - us-east-1
+

--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -352,11 +352,11 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 9
+    Default: 11
     AllowedValues:
-      - 9
-      - 10
       - 11
+      - 10
+      - 9
     Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this."
     Type: String
   DBInstanceClass:
@@ -543,7 +543,7 @@ Parameters:
       - ServiceManagement
       - All
   JiraVersion:
-    Default: "8.13.2"
+    Default: "8.13.3"
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.14.0 for Jira Software, or 4.14.0 for Jira Service Management.
     Description: The version of Jira Software or Jira Service Management to install. If choosing Jira All, pick the version of Jira Software and the latest compatible version of Jira Service Management will be selected automatically. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Management), or https://confluence.atlassian.com/x/XM2EO (Long Term Support releases).

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -337,11 +337,11 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 9
+    Default: 11
     AllowedValues:
-      - 9
-      - 10
       - 11
+      - 10
+      - 9
     Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected. Check https://confluence.atlassian.com/x/bqr1Nw to verify this."
     Type: String
   DBInstanceClass:
@@ -534,7 +534,7 @@ Parameters:
       - ServiceManagement
       - All
   JiraVersion:
-    Default: "8.13.2"
+    Default: "8.13.3"
     AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
     ConstraintDescription: Must be a valid version number or 'latest'; for example, 8.14.0 for Jira Software, or 4.14.0 for Jira Service Management.
     Description: The version of Jira Software or Jira Service Management to install. If choosing Jira All, pick the version of Jira Software and the latest compatible version of Jira Service Management will be selected automatically. Find valid versions at https://confluence.atlassian.com/x/TVlNLg (Jira Software), https://confluence.atlassian.com/x/jh9-Lg (Jira Service Management), or https://confluence.atlassian.com/x/XM2EO (Long Term Support releases).
@@ -1068,10 +1068,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 967bce1c42a0ed818fae85170cc73cd53740220f"
+          Value: "COMMIT: b4f4ca87b4116ef08abe6f875f9f999a2fda6ee5"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:21:04Z"
+          Value: "TIMESTAMP: 2021-02-09T06:41:39Z"
           PropagateAtLaunch: true
 
   ClusterNodeLaunchConfig:
@@ -1256,9 +1256,9 @@ Resources:
           Value: !Ref AWS::StackId
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 967bce1c42a0ed818fae85170cc73cd53740220f"
+          Value: "COMMIT: b4f4ca87b4116ef08abe6f875f9f999a2fda6ee5"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:21:04Z"
+          Value: "TIMESTAMP: 2021-02-09T06:41:39Z"
   EFSMountAz1:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -1344,9 +1344,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 967bce1c42a0ed818fae85170cc73cd53740220f"
+          Value: "COMMIT: b4f4ca87b4116ef08abe6f875f9f999a2fda6ee5"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:21:04Z"
+          Value: "TIMESTAMP: 2021-02-09T06:41:39Z"
 
   LoadBalancerHTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -1408,9 +1408,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 967bce1c42a0ed818fae85170cc73cd53740220f"
+          Value: "COMMIT: b4f4ca87b4116ef08abe6f875f9f999a2fda6ee5"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:21:04Z"
+          Value: "TIMESTAMP: 2021-02-09T06:41:39Z"
     DependsOn:
       - LoadBalancer
   LoadBalancerCname:
@@ -1489,9 +1489,9 @@ Resources:
           Value: !Join [' ', [!Ref "AWS::StackName", 'sg']]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 967bce1c42a0ed818fae85170cc73cd53740220f"
+          Value: "COMMIT: b4f4ca87b4116ef08abe6f875f9f999a2fda6ee5"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:21:04Z"
+          Value: "TIMESTAMP: 2021-02-09T06:41:39Z"
       VpcId:
         Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
   SecurityGroupIngress:
@@ -1523,9 +1523,9 @@ Resources:
           Value: !Sub ["${StackName} Encryption Key", {StackName: !Ref 'AWS::StackName'}]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 967bce1c42a0ed818fae85170cc73cd53740220f"
+          Value: "COMMIT: b4f4ca87b4116ef08abe6f875f9f999a2fda6ee5"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:21:04Z"
+          Value: "TIMESTAMP: 2021-02-09T06:41:39Z"
   EncryptionKeyAlias:
     Condition: UseDatabaseEncryption
     Type: AWS::KMS::Alias


### PR DESCRIPTION
* Add support for Postgres 12
* Make Postgres 11 default database engine (latest supported by Jira)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
