### PR TITLE
DCD-1354 Eliminate unused KMS actions on AWS Quickstart

### DIFF
--- a/ci/params/aurora/quickstart-jira-dc-aurora-params.json
+++ b/ci/params/aurora/quickstart-jira-dc-aurora-params.json
@@ -42,5 +42,9 @@
   {
     "ParameterKey": "BastionHostRequired",
     "ParameterValue": "false"
+  },
+  {
+      "ParameterKey": "DeploymentAutomationBranch",
+      "ParameterValue": "master"
   }
 ]

--- a/ci/params/default/quickstart-jira-default-params.json
+++ b/ci/params/default/quickstart-jira-default-params.json
@@ -50,5 +50,9 @@
     {
         "ParameterKey": "BastionHostRequired",
         "ParameterValue": "false"
+    },
+    {
+        "ParameterKey": "DeploymentAutomationBranch",
+        "ParameterValue": "master"
     }
 ]

--- a/ci/params/ssl-and-dns/quickstart-jira-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-jira-ci-params.json
@@ -58,5 +58,9 @@
     {
         "ParameterKey": "BastionHostRequired",
         "ParameterValue": "false"
+    },
+    {
+        "ParameterKey": "DeploymentAutomationBranch",
+        "ParameterValue": "master"
     }
 ]

--- a/templates/quickstart-jira-dc.template.yaml
+++ b/templates/quickstart-jira-dc.template.yaml
@@ -1526,56 +1526,21 @@ Resources:
               AWS:
                 - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
             Action:
-              - kms:CancelKeyDeletion
-              - kms:ConnectCustomKeyStore
               - kms:CreateAlias
-              - kms:CreateCustomKeyStore
               - kms:CreateGrant
               - kms:CreateKey
-              - kms:Decrypt
               - kms:DeleteAlias
-              - kms:DeleteCustomKeyStore
               - kms:DeleteImportedKeyMaterial
-              - kms:DescribeCustomKeyStores
               - kms:DescribeKey
               - kms:DisableKey
               - kms:DisableKeyRotation
-              - kms:DisconnectCustomKeyStore
               - kms:EnableKey
               - kms:EnableKeyRotation
-              - kms:Encrypt
-              - kms:GenerateDataKey
-              - kms:GenerateDataKeyPair
-              - kms:GenerateDataKeyPairWithoutPlaintext
-              - kms:GenerateDataKeyWithoutPlaintext
-              - kms:GenerateRandom
               - kms:GetKeyPolicy
               - kms:GetKeyRotationStatus
               - kms:GetParametersForImport
               - kms:GetPublicKey
-              - kms:ImportKeyMaterial
-              - kms:ListAliases
-              - kms:ListGrants
-              - kms:ListKeyPolicies
-              - kms:ListKeys
-              - kms:ListResourceTags
-              - kms:ListRetirableGrants
               - kms:PutKeyPolicy
-              - kms:ReEncryptFrom
-              - kms:ReEncryptTo
-              - kms:ReplicateKey
-              - kms:RetireGrant
-              - kms:RevokeGrant
-              - kms:ScheduleKeyDeletion
-              - kms:Sign
-              - kms:SynchronizeMultiRegionKey
-              - kms:TagResource
-              - kms:UntagResource
-              - kms:UpdateAlias
-              - kms:UpdateCustomKeyStore
-              - kms:UpdateKeyDescription
-              - kms:UpdatePrimaryRegion
-              - kms:Verify
             Resource: '*'
       EnableKeyRotation: true
       Tags:


### PR DESCRIPTION
*DCD-1354*

- Eliminate unused KMS actions on AWS Quickstart
- Enable the DeploymentAutomationBranch override

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.