### PR TITLE
Increases the ARN of the ACM certificate length

### DIFF
--- a/templates/quickstart-jira-dc-with-vpc.template.yaml
+++ b/templates/quickstart-jira-dc-with-vpc.template.yaml
@@ -583,7 +583,7 @@ Parameters:
     Default: ''
     Description: "Amazon Resource Name (ARN) of your SSL certificate. Supplying this will automatically enable HTTPS on the product and load balancer, configured to use the corresponding certificate. If you want to use your own certificate that you generated outside of Amazon, you need to first import it to AWS Certificate Manager. After a successful import, you'll receive the ARN. If you want to create a certificate with AWS Certificate Manager (ACM certificate), you will receive the ARN after it's successfully created."
     MinLength: 0
-    MaxLength: 90
+    MaxLength: 100
     Type: String
   TomcatAcceptCount:
     Default: 10


### PR DESCRIPTION
GovCloud ARNs are a bit longer than 90 characters.

*Issue #, if available:*

*Description of changes: In GovCloud, the ARN of my ACM certificate was longer than 90 characters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
